### PR TITLE
Fix import statement

### DIFF
--- a/ios/RNAudioJack.h
+++ b/ios/RNAudioJack.h
@@ -1,7 +1,7 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNAudioJack : NSObject <RCTBridgeModule>


### PR DESCRIPTION
This fixes some build errors with modern versions of react native. Building the module results in a build error: `Redefinition of RCTMethodInfo`.

https://github.com/facebook/react-native/issues/15775