### PR TITLE
Fix breaking change w/ Gradle dependencies 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-jack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Intent
This fixes a breaking API change with the Android Gradle plugin, which was deprecated as of version 3.0.0 and later made obsolete. 

## Changes
When adding Gradle dependencies, the `compile` command has been removed and replaced with `implementation`/`api`.

## More information
- [Gradle support docs](https://docs.gradle.org/5.4.1/userguide/java_library_plugin.html#sec:java_library_separation)
- [Android deprecation doc](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations)