### PR TITLE
Fix requiresMainQueueSetup warnings

### DIFF
--- a/ios/RNAudioJack.m
+++ b/ios/RNAudioJack.m
@@ -22,6 +22,11 @@ RCT_EXPORT_MODULE(AudioJack)
 static NSString * const AUDIO_CHANGED_NOTIFICATION = @"AUDIO_CHANGED_NOTIFICATION";
 static NSString * const IS_PLUGGED_IN = @"isPluggedIn";
 
++ (BOOL)requiresMainQueueSetup
+{
+   return YES;
+}
+
 - (instancetype)init
 {
     if (self = [super init]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-jack",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
This fixes some of the warnings we were getting about requiring main queue setup in our native modules, by explicitly setting whether our native modules can be loaded in the background.

## Prior art:
https://github.com/wix/react-native-navigation/pull/1983/files
https://github.com/facebook/react-native/commit/220034c4d4c8a52f424e05c291a62b63b74447f3
https://github.com/invertase/react-native-firebase/issues/491