### PR TITLE
[PODS] Add required homepage attribute to podspec

### DIFF
--- a/ios/RNAudioJack.podspec
+++ b/ios/RNAudioJack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNAudioJack
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/robinpowered/react-native-audio-jack"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Hi and thanks for the library!
Since React Native 0.60, we have to use Podfile and the one provided with this module breaks the compilation because of a blank string provided in the required homepage attribute. This PR set the homepage to this repository so you can compile iOS projects. 🎉