### PR TITLE
set homepage to a url to avoid errors

### DIFF
--- a/ios/RNAudioJack.podspec
+++ b/ios/RNAudioJack.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNAudioJack
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/robinpowered/react-native-audio-jack"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Setting `homepage` to an empty string causes a `pod install` error.

This sets the homepage to the github repo.